### PR TITLE
Correct case in filename for linux compatibility

### DIFF
--- a/src/fatfs/diskio.h
+++ b/src/fatfs/diskio.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-#include "FF.h" // Added by Rohan, otherwise errors
+#include "ff.h" // Added by Rohan, otherwise errors
 
 
 /* Status of Disk Functions */


### PR DESCRIPTION
diskio includes "FF.h" which works on windows but not linux, the file is actually named ff.h